### PR TITLE
Convert MATLAB ray tracing code to Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,21 @@
-Ray tracing for Boun Photonics Lab
-- Edit mirror function for light coming from different directions
-- add cyl lens
-- differernt kinds of light sources
-- 2d optic table
-- aperture
+# RayTracing
+
+This repository demonstrates a simple ray tracing setup initially developed for the Boun Photonics Lab.
+
+Both the original MATLAB scripts and a Python port are provided.
+
+## MATLAB version
+
+Run the `RayTracing.m` script from MATLAB or Octave to reproduce the demo.
+
+## Python version
+
+Install the required libraries and execute `ray_tracing.py`:
+
+```
+pip install matplotlib numpy
+python ray_tracing.py
+```
+
+The Python workflow mirrors the MATLAB example by drawing an object, passing rays through a lens and mirror, and finally plotting the result.
+

--- a/image_plane.py
+++ b/image_plane.py
@@ -1,0 +1,6 @@
+import matplotlib.pyplot as plt
+
+
+def image_plane(Ximg, Yimg):
+    """Draw the image plane as a vertical green line."""
+    plt.plot([Ximg, Ximg], [0, Yimg], 'g', linewidth=2)

--- a/lens.py
+++ b/lens.py
@@ -1,0 +1,34 @@
+import numpy as np
+import matplotlib.pyplot as plt
+
+
+def lens(Xobj, Yobj, Xlens, f, way, draw_lens):
+    """Calculate the image from a thin lens and optionally draw the lens."""
+    if way == 'L':
+        Xdiff = Xlens - Xobj
+        Xdiffimg = (Xdiff * f) / (Xdiff - f)
+        Ximg = Xlens + Xdiffimg
+        Yimg = -(Xdiffimg * Yobj) / Xdiff
+    else:
+        Xdiff = Xobj - Xlens
+        Xdiffimg = (Xdiff * f) / (Xdiff - f)
+        Ximg = Xlens - Xdiffimg
+        Yimg = -(Xdiffimg * Yobj) / Xdiff
+
+    if draw_lens == 1:
+        angle = np.arange(2 * np.pi / 3, 4 * np.pi / 3, 0.001)
+        R = Yobj * 1.5
+        if f > 0:
+            plt.plot(Xlens + R / 2 + R * np.cos(angle), R * np.sin(angle), 'b', linewidth=2)
+            plt.plot(Xlens - R / 2 + R * np.cos(angle + np.pi),
+                     R * np.sin(angle + np.pi), 'b', linewidth=2)
+        else:
+            plt.plot(Xlens - R + R * np.cos(angle + np.pi),
+                     R * np.sin(angle + np.pi), 'b', linewidth=2)
+            plt.plot(Xlens + R + R * np.cos(angle),
+                     R * np.sin(angle), 'b', linewidth=2)
+
+    plt.plot([Xobj, Ximg], [Yobj, Yimg], 'k--', linewidth=1)
+    plt.plot([Xobj, Xlens], [Yobj, Yobj], 'k--', linewidth=1)
+    plt.plot([Xlens, Ximg], [Yobj, Yimg], 'k--', linewidth=1)
+    return Ximg, Yimg

--- a/mirror.py
+++ b/mirror.py
@@ -1,0 +1,30 @@
+import numpy as np
+import matplotlib.pyplot as plt
+
+
+def mirror(Xobj, Yobj, Xmirror, f, way):
+    """Calculate the image from a mirror and draw the mirror."""
+    Xdiff = Xmirror - Xobj
+    Xdiffimg = (Xdiff * f) / (Xdiff - f)
+    Ximg = Xmirror - Xdiffimg
+    Yimg = -(Xdiffimg * Yobj) / Xdiff
+
+    if way == 'L':
+        way = 'R'
+    else:
+        way = 'L'
+
+    angle = np.arange(2 * np.pi / 3, 4 * np.pi / 3, 0.001)
+    R = Yobj * 1.5
+    if f > 0:
+        plt.plot(Xmirror - R + R * np.cos(angle + np.pi),
+                 R * np.sin(angle + np.pi), 'b', linewidth=2)
+    else:
+        plt.plot(Xmirror + R + R * np.cos(angle),
+                 R * np.sin(angle), 'b', linewidth=2)
+
+    plt.plot([Xobj, Xmirror], [Yobj, 0], 'k--', linewidth=1)
+    plt.plot([Xmirror, Ximg], [0, Yimg], 'k--', linewidth=1)
+    plt.plot([Xobj, Xmirror], [Yobj, Yobj], 'k--', linewidth=1)
+    plt.plot([Xmirror, Ximg], [Yobj, Yimg], 'k--', linewidth=1)
+    return Ximg, Yimg, way

--- a/obj.py
+++ b/obj.py
@@ -1,0 +1,7 @@
+import matplotlib.pyplot as plt
+
+
+def obj(Xobj, y):
+    """Draws the object as a vertical red line."""
+    plt.plot([Xobj, Xobj], [0, y], 'r', linewidth=2)
+    return Xobj, y

--- a/ray_tracing.py
+++ b/ray_tracing.py
@@ -1,0 +1,32 @@
+import matplotlib.pyplot as plt
+
+from obj import obj
+from lens import lens
+from mirror import mirror
+from image_plane import image_plane
+
+
+def main():
+    plt.figure()
+
+    way = 'L'
+    Xobj, Yobj = obj(15, 1)
+
+    Ximg, Yimg = lens(Xobj, Yobj, 30, -10, way, 1)
+    image_plane(Ximg, Yimg)
+
+    Ximg, Yimg, way = mirror(Ximg, Yimg, 60, 10, way)
+    image_plane(Ximg, Yimg)
+
+    Ximg, Yimg = lens(Ximg, Yimg, 30, -10, way, 0)
+    image_plane(Ximg, Yimg)
+    m = Yimg / Yobj
+
+    lim = plt.xlim()
+    plt.plot([lim[0], lim[1]], [0, 0], 'k', linewidth=1.5)
+    plt.gcf().canvas.draw()  # ensures limits are respected before showing
+    plt.show()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- port original MATLAB scripts to Python
- document new Python workflow
- improve README with instructions for MATLAB and Python versions

## Testing
- `pip install matplotlib numpy > /tmp/pip.log && tail -n 20 /tmp/pip.log`
- `python ray_tracing.py > /tmp/py.log && tail -n 20 /tmp/py.log`


------
https://chatgpt.com/codex/tasks/task_e_6842fcd6d57883239731cbbbeaecd457