### PR TITLE
Extend optical library with new components

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ The repository includes the following modules:
 - `ray_tracing.py` – example script that builds a small optical system.
 - `lens.py` – computes the imaging properties of a thin lens.
 - `mirror.py` – models reflection from a spherical mirror.
+- `plane_mirror.py` – reflects rays from a flat mirror.
+- `aperture.py` – draws an aperture used to limit the beam height.
 - `obj.py` – draws a simple object at a given location.
 - `image_plane.py` – helper used to draw the resulting image plane.
 
@@ -21,4 +23,4 @@ pip install matplotlib numpy
 python ray_tracing.py
 ```
 
-The script will open a figure and plot the object, lens, mirror and final image plane. You can edit the parameters inside `ray_tracing.py` to experiment with different object positions or focal lengths.
+The script will open a figure showing the object, lenses, mirror, aperture and plane mirror along with the final image plane. You can edit the parameters inside `ray_tracing.py` to experiment with different object positions or focal lengths.

--- a/aperture.py
+++ b/aperture.py
@@ -1,0 +1,15 @@
+import matplotlib.pyplot as plt
+
+
+def aperture(Xaperture, size):
+    """Draw a simple aperture.
+
+    Parameters
+    ----------
+    Xaperture : float
+        Position of the aperture along the X axis.
+    size : float
+        Total height of the aperture opening.
+    """
+    half = size / 2.0
+    plt.plot([Xaperture, Xaperture], [-half, half], 'm', linewidth=2)

--- a/image_plane.py
+++ b/image_plane.py
@@ -2,5 +2,11 @@ import matplotlib.pyplot as plt
 
 
 def image_plane(Ximg, Yimg):
-    """Draw the image plane as a vertical green line."""
+    """Draw the image plane.
+
+    Parameters
+    ----------
+    Ximg, Yimg : float
+        Coordinates of the image point.
+    """
     plt.plot([Ximg, Ximg], [0, Yimg], 'g', linewidth=2)

--- a/lens.py
+++ b/lens.py
@@ -3,7 +3,27 @@ import matplotlib.pyplot as plt
 
 
 def lens(Xobj, Yobj, Xlens, f, way, draw_lens):
-    """Calculate the image from a thin lens and optionally draw the lens."""
+    """Thin lens imaging.
+
+    Parameters
+    ----------
+    Xobj, Yobj : float
+        Coordinates of the object.
+    Xlens : float
+        Position of the lens along the X axis.
+    f : float
+        Focal length of the lens (positive for converging, negative for
+        diverging).
+    way : {'L', 'R'}
+        Direction of propagation.
+    draw_lens : int
+        If non-zero, the lens is drawn on the current matplotlib axes.
+
+    Returns
+    -------
+    tuple
+        (Ximg, Yimg) coordinates of the image produced by the lens.
+    """
     if way == 'L':
         Xdiff = Xlens - Xobj
         Xdiffimg = (Xdiff * f) / (Xdiff - f)

--- a/mirror.py
+++ b/mirror.py
@@ -3,7 +3,25 @@ import matplotlib.pyplot as plt
 
 
 def mirror(Xobj, Yobj, Xmirror, f, way):
-    """Calculate the image from a mirror and draw the mirror."""
+    """Spherical mirror imaging.
+
+    Parameters
+    ----------
+    Xobj, Yobj : float
+        Coordinates of the object.
+    Xmirror : float
+        Position of the mirror along the X axis.
+    f : float
+        Mirror focal length (positive for concave, negative for convex).
+    way : {'L', 'R'}
+        Direction of propagation before reflection.
+
+    Returns
+    -------
+    tuple
+        (Ximg, Yimg, way) with the new image coordinates and updated
+        propagation direction.
+    """
     Xdiff = Xmirror - Xobj
     Xdiffimg = (Xdiff * f) / (Xdiff - f)
     Ximg = Xmirror - Xdiffimg

--- a/obj.py
+++ b/obj.py
@@ -2,6 +2,14 @@ import matplotlib.pyplot as plt
 
 
 def obj(Xobj, y):
-    """Draws the object as a vertical red line."""
+    """Draw an object in the scene.
+
+    Parameters
+    ----------
+    Xobj : float
+        Position along the X axis.
+    y : float
+        Height of the object.
+    """
     plt.plot([Xobj, Xobj], [0, y], 'r', linewidth=2)
     return Xobj, y

--- a/plane_mirror.py
+++ b/plane_mirror.py
@@ -1,0 +1,30 @@
+import matplotlib.pyplot as plt
+
+
+def plane_mirror(Xobj, Yobj, Xmirror, way):
+    """Reflects the ray from a flat mirror and returns the virtual image.
+
+    Parameters
+    ----------
+    Xobj, Yobj : float
+        Object location.
+    Xmirror : float
+        Position of the mirror along the X axis.
+    way : {'L', 'R'}
+        Direction of propagation before reflection.
+
+    Returns
+    -------
+    tuple
+        (Ximg, Yimg, way) - coordinates of the virtual image and new
+        propagation direction.
+    """
+    Ximg = 2 * Xmirror - Xobj
+    Yimg = Yobj
+
+    plt.plot([Xmirror, Xmirror], [0, Yobj * 1.5], 'b', linewidth=2)
+    plt.plot([Xobj, Xmirror], [Yobj, Yobj], 'k--', linewidth=1)
+    plt.plot([Xmirror, Ximg], [Yobj, Yimg], 'k--', linewidth=1)
+
+    way = 'R' if way == 'L' else 'L'
+    return Ximg, Yimg, way

--- a/ray_tracing.py
+++ b/ray_tracing.py
@@ -3,6 +3,8 @@ import matplotlib.pyplot as plt
 from obj import obj
 from lens import lens
 from mirror import mirror
+from plane_mirror import plane_mirror
+from aperture import aperture
 from image_plane import image_plane
 
 
@@ -12,10 +14,15 @@ def main():
     way = 'L'
     Xobj, Yobj = obj(15, 1)
 
+    aperture(22, 2)
+
     Ximg, Yimg = lens(Xobj, Yobj, 30, -10, way, 1)
     image_plane(Ximg, Yimg)
 
     Ximg, Yimg, way = mirror(Ximg, Yimg, 60, 10, way)
+    image_plane(Ximg, Yimg)
+
+    Ximg, Yimg, way = plane_mirror(Ximg, Yimg, 80, way)
     image_plane(Ximg, Yimg)
 
     Ximg, Yimg = lens(Ximg, Yimg, 30, -10, way, 0)


### PR DESCRIPTION
## Summary
- add new `plane_mirror` element and `aperture` helper
- update sample ray tracing script to showcase new elements
- improve docstrings across modules
- document new modules in the README

## Testing
- `pip install matplotlib numpy`
- `python ray_tracing.py`

------
https://chatgpt.com/codex/tasks/task_e_6866f246026c8323ade7fdc97fd9e874