### PR TITLE
Fix spherical mirror orientation

### DIFF
--- a/mirror.py
+++ b/mirror.py
@@ -22,9 +22,14 @@ def mirror(Xobj, Yobj, Xmirror, f, way):
         (Ximg, Yimg, way) with the new image coordinates and updated
         propagation direction.
     """
-    Xdiff = Xmirror - Xobj
-    Xdiffimg = (Xdiff * f) / (Xdiff - f)
-    Ximg = Xmirror - Xdiffimg
+    if way == 'L':
+        Xdiff = Xmirror - Xobj
+        Xdiffimg = (Xdiff * f) / (Xdiff - f)
+        Ximg = Xmirror - Xdiffimg
+    else:
+        Xdiff = Xobj - Xmirror
+        Xdiffimg = (Xdiff * f) / (Xdiff - f)
+        Ximg = Xmirror + Xdiffimg
     Yimg = -(Xdiffimg * Yobj) / Xdiff
 
     if way == 'L':

--- a/tests/test_mirror.py
+++ b/tests/test_mirror.py
@@ -13,3 +13,10 @@ def test_mirror_basic():
     assert x_img == 0.0
     assert y_img == -1.0
     assert way == 'R'
+
+
+def test_mirror_right_side():
+    x_img, y_img, way = mirror(20, 1, 10, 5, 'R')
+    assert way == 'L'
+    assert y_img == -1.0
+    assert x_img == 20.0


### PR DESCRIPTION
## Summary
- handle rays coming from the right side in `mirror`
- add regression test for right-side mirror case

## Testing
- `pytest -q`
- `python ray_tracing.py`

------
https://chatgpt.com/codex/tasks/task_e_68670677d0ec8323ba1eb51735ccfb5d